### PR TITLE
Add values field for option clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Add `values` field for options. Any option directly passed by command line
+  flag or environment variable must be one of the listed values, if specified.
+
 ### Fixed
 - Fix various issues with Zsh tab completions.
 

--- a/config/option/option_test.go
+++ b/config/option/option_test.go
@@ -287,9 +287,8 @@ var unmarshalOptionErrorTests = []struct {
 }
 
 func TestOption_UnmarshalYAML_invalid_definitions(t *testing.T) {
-	o := Option{}
-
 	for _, tt := range unmarshalOptionErrorTests {
+		o := Option{}
 		if err := yaml.Unmarshal([]byte(tt.input), &o); err == nil {
 			t.Errorf(
 				"yaml.Unmarshal(%s, ...): expected error for %s, actual nil",


### PR DESCRIPTION
Any option passed by command line or environment variables must be one
of the listed values, if specified. Does not affect default values.

Syntax is as follows:

```yaml
options:
  opt:
    values:
      - foo
      - bar
    default: baz
```

And when invoked:

```bash
# valid
tusk task
tusk task --opt foo
tusk task --opt bar

# invalid
tusk task --opt baz
tusk task --opt other
```