### PR TITLE
Update to latest golangci-lint

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -2,7 +2,8 @@ FROM golang:1.11.1
 
 WORKDIR /tusk
 
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.11
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh \
+      | bash -s -- -b $GOPATH/bin v1.12.2
 RUN go get github.com/jstemmer/go-junit-report
 RUN apt-get update && \
       apt-get -y install rpm && \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ defaults:
   job_defaults: &job_defaults
     working_directory: /tusk
     docker:
-      - image: tuskcli/ci:0.2.0
+      - image: tuskcli/ci:0.2.1
     environment: &environment_defaults
       TEST_RESULTS: /tmp/test-results
   job_dry_run: &job_dry_run

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -16,9 +16,11 @@ exclude-use-default = false
 [linters]
 enable-all = true
 disable = [
-  "maligned",
+  "gochecknoglobals", # There are valid use cases for globals
+  "goimports",        # Performance: https://github.com/golangci/golangci-lint/issues/263
+  "maligned",         # Readability is more important than saving bytes
+  "scopelint",        # False positives in tests: https://github.com/kyoh86/scopelint/issues/4
 ]
-fast = false
 
 [linters-settings]
 

--- a/appcli/help.go
+++ b/appcli/help.go
@@ -8,7 +8,7 @@ import (
 )
 
 // init sets the help templates for urfave/cli.
-// nolint: lll
+// nolint: lll, gochecknoinits
 func init() {
 
 	cli.HelpPrinter = helpPrinter


### PR DESCRIPTION
Disables errors I don't care about when updating to the latest version of `golangci-lint` locally.