### PR TITLE
Install custom go version in appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,18 +4,19 @@ branches:
   only:
     - master
 
-clone_folder: c:\tusk
-
 environment:
   GOPATH: c:\gopath
+  GO_VERSION: 1.12.1
 
-stack: go 1.11
-
-init:
+install:
+  # Install specific Go version
+  - rmdir c:\go /s /q
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go%GO_VERSION%.windows-amd64.msi
+  - msiexec /i go%GO_VERSION%.windows-amd64.msi /q
   # Add GOPATH to reference installed binary
   - set PATH=%GOPATH%\bin;%PATH%
   # Add MinGW for gcc
-  - set PATH=C:\msys64\mingw64\bin;%PATH%
+  - set PATH=c:\msys64\mingw64\bin;%PATH%
 
 build_script:
   - go install

--- a/appcli/completion.go
+++ b/appcli/completion.go
@@ -115,7 +115,7 @@ func printCommand(command *cli.Command) {
 	fmt.Printf(
 		"%s:%s\n",
 		command.Name,
-		strings.Replace(command.Usage, "\n", "", -1),
+		strings.ReplaceAll(command.Usage, "\n", ""),
 	)
 }
 
@@ -128,7 +128,7 @@ func printFlag(c *cli.Context, flag cli.Flag) {
 		fmt.Printf(
 			"--%s:%s\n",
 			value,
-			strings.Replace(getDescription(flag), "\n", "", -1),
+			strings.ReplaceAll(getDescription(flag), "\n", ""),
 		)
 	}
 }

--- a/appcli/help.go
+++ b/appcli/help.go
@@ -53,7 +53,7 @@ func helpPrinter(out io.Writer, templ string, data interface{}) {
 	customFunc := map[string]interface{}{
 		"indent": func(spaces int, text string) string {
 			padding := strings.Repeat(" ", spaces)
-			return padding + strings.Replace(text, "\n", "\n"+padding, -1)
+			return padding + strings.ReplaceAll(text, "\n", "\n"+padding)
 		},
 	}
 

--- a/interp/main.go
+++ b/interp/main.go
@@ -43,7 +43,7 @@ func FindPotentialVariables(text []byte) []string {
 
 // escape escapes all instances of $$ with $.
 func escape(text []byte) []byte {
-	return bytes.Replace(text, []byte("$$"), []byte("$"), -1)
+	return bytes.ReplaceAll(text, []byte("$$"), []byte("$"))
 }
 
 // interpolate replaces instances of the name pattern with the value.
@@ -82,10 +82,10 @@ func compile(name string) (*regexp.Regexp, error) {
 
 // escapePattern escapes unwanted potential interpolation targets.
 func escapePattern(text []byte) []byte {
-	return bytes.Replace(text, []byte("$$"), escSeq, -1)
+	return bytes.ReplaceAll(text, []byte("$$"), escSeq)
 }
 
 // unescapePattern returns unwanted potential interpolation targets.
 func unescapePattern(text []byte) []byte {
-	return bytes.Replace(text, escSeq, []byte("$$"), -1)
+	return bytes.ReplaceAll(text, escSeq, []byte("$$"))
 }


### PR DESCRIPTION
Currently AppVeyor doesn't ship with Go 1.12, meaning Tusk can't both be bleeding edge and rely on the preinstalled Go versions. 

This PR changes the logic back to manually installing Go so we can keep Windows CI in sync.