### PR TITLE
Added not-exists and updated documentation.

### DIFF
--- a/appcli/app.go
+++ b/appcli/app.go
@@ -18,7 +18,7 @@ func newBaseApp() *cli.App {
 	app.HideVersion = true
 	app.HideHelp = true
 	app.EnableBashCompletion = true
-	// app.UseShortOptionHandling = true
+	app.UseShortOptionHandling = true
 	app.ExitErrHandler = func(*cli.Context, error) {}
 
 	app.Flags = append(app.Flags,

--- a/appcli/app.go
+++ b/appcli/app.go
@@ -18,7 +18,7 @@ func newBaseApp() *cli.App {
 	app.HideVersion = true
 	app.HideHelp = true
 	app.EnableBashCompletion = true
-	app.UseShortOptionHandling = true
+	// app.UseShortOptionHandling = true
 	app.ExitErrHandler = func(*cli.Context, error) {}
 
 	app.Flags = append(app.Flags,

--- a/config/when/testutils.go
+++ b/config/when/testutils.go
@@ -49,6 +49,13 @@ func WithExists(filename string) func(w *When) {
 	}
 }
 
+// WithNotExists returns an operator that requires a file to not exist.
+func WithNotExists(filename string) func(w *When) {
+	return func(w *When) {
+		w.NotExists = append(w.NotExists, filename)
+	}
+}
+
 // WithOS returns an operator that requires an arbitrary OS.
 func WithOS(name string) func(w *When) {
 	return func(w *When) {

--- a/config/when/when.go
+++ b/config/when/when.go
@@ -175,15 +175,13 @@ func (w *When) validateNotExists() error {
 	for _, f := range w.NotExists {
 		if _, err := os.Stat(f); err != nil {
 			if os.IsNotExist(err) {
-				continue
+				return nil
 			}
 			return err
 		}
-
-		return newCondFailErrorf("file exists, but shouldn't: %s", w.NotExists)
 	}
 
-	return nil
+	return newCondFailErrorf("all files exist: %s", w.NotExists)
 }
 
 func (w *When) validateOS() error {

--- a/config/when/when_test.go
+++ b/config/when/when_test.go
@@ -152,6 +152,13 @@ var whenValidateTests = []struct {
 	{Create(WithExists("when_test.go"), WithExists("fakefile")), nil, false},
 	{Create(WithExists("fakefile"), WithExists("fakefile2")), nil, true},
 
+	// Not Exist Clauses
+	{Create(WithNotExists("when_test.go")), nil, true},
+	{Create(WithNotExists("fakefile")), nil, false},
+	{Create(WithNotExists("fakefile"), WithNotExists("when_test.go")), nil, true},
+	{Create(WithNotExists("when_test.go"), WithNotExists("fakefile")), nil, true},
+	{Create(WithNotExists("fakefile"), WithNotExists("fakefile2")), nil, false},
+
 	// OS Clauses
 	{Create(WithOSSuccess), nil, false},
 	{Create(WithOSFailure), nil, true},

--- a/config/when/when_test.go
+++ b/config/when/when_test.go
@@ -155,8 +155,8 @@ var whenValidateTests = []struct {
 	// Not Exist Clauses
 	{Create(WithNotExists("when_test.go")), nil, true},
 	{Create(WithNotExists("fakefile")), nil, false},
-	{Create(WithNotExists("fakefile"), WithNotExists("when_test.go")), nil, true},
-	{Create(WithNotExists("when_test.go"), WithNotExists("fakefile")), nil, true},
+	{Create(WithNotExists("fakefile"), WithNotExists("when_test.go")), nil, false},
+	{Create(WithNotExists("when_test.go"), WithNotExists("fakefile")), nil, false},
 	{Create(WithNotExists("fakefile"), WithNotExists("fakefile2")), nil, false},
 
 	// OS Clauses

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -167,8 +167,8 @@ five different checks supported:
 - `command` (list): Execute if any command runs with an exit code of `0`.
   Commands will execute in the order defined and stop execution at the first
   successful command.
-- `exists` (list): Execute if all files listed exists.
-- `not-exists` (list): Execute if all files listed doesn't exists.
+- `exists` (list): Execute if any of the listed files exists.
+- `not-exists` (list): Execute if any of the listed files doesn't exists.
 - `os` (list): Execute if the operating system matches any one from the list.
 - `environment` (map[string -> list]): Execute if the environment variable
   matches any of the values it maps to. To check if a variable is not set, the

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -167,7 +167,8 @@ five different checks supported:
 - `command` (list): Execute if any command runs with an exit code of `0`.
   Commands will execute in the order defined and stop execution at the first
   successful command.
-- `exists` (list): Execute if any file listed exists.
+- `exists` (list): Execute if all files listed exists.
+- `not-exists` (list): Execute if all files listed doesn't exists.
 - `os` (list): Execute if the operating system matches any one from the list.
 - `environment` (map[string -> list]): Execute if the environment variable
   matches any of the values it maps to. To check if a variable is not set, the


### PR DESCRIPTION
I found it quite annoying to setup a cross-platform file checking manually (with type/cat/exit codes and stuff). This was really missing.

Also documentation wasn't reflecting the actual behavior of exists, so I updated it. And there was an error with CLI (maybe some deprecated variable that I commented out)

I'd love to see this published since I'm integrating tusk in a public project CI pipelines and it will fetch the latest `tusk` release automatically :), otherwise I'll need to create a custom release somewhere else.



