### PR TITLE
Update go, circleci, and golangci-lint versions

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,7 +6,7 @@ branches:
 
 environment:
   GOPATH: c:\gopath
-  GO_VERSION: 1.12.1
+  GO_VERSION: 1.12.6
 
 install:
   # Install specific Go version

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.12.1
+FROM golang:1.12.6
 
 WORKDIR /tusk
 
 RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh \
-      | bash -s -- -b $GOPATH/bin v1.15.0
+      | bash -s -- -b $GOPATH/bin v1.17.1
 RUN go get github.com/jstemmer/go-junit-report
 RUN apt-get update && \
       apt-get -y install rpm && \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ defaults:
   job_defaults: &job_defaults
     working_directory: /tusk
     docker:
-      - image: tuskcli/ci:0.2.3
+      - image: tuskcli/ci:0.2.4
     environment: &environment_defaults
       TEST_RESULTS: /tmp/test-results
   job_dry_run: &job_dry_run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,8 +48,7 @@ defaults:
 
 version: 2
 jobs:
-  # For running tests locally
-  build:
+  local:
     <<: *job_dry_run
     steps:
       - checkout

--- a/tusk.yml
+++ b/tusk.yml
@@ -7,14 +7,24 @@ tasks:
       application.
     options:
       bin-dir:
-        usage: The location for binary files. Defaults to $GOPATH/bin
-        default: $(go env GOPATH)/bin
+        usage: The location for binary files. Defaults to /usr/local/bin
+        default: /usr/local/bin
       golangci-url:
         private: true
         default: https://install.goreleaser.com/github.com/golangci/golangci-lint.sh
+      golangci-version:
+        private: true
+        default: 1.15.0
     run:
-      - curl -sfL ${golangci-url} | bash -s -- -b $(go env GOPATH)/bin v1.15.0
-      - go get -u golang.org/x/tools/cmd/goimports
+      - when:
+          command: golangci-lint --version | grep -qv ${golangci-version}
+        command: curl -fLSs ${golangci-url} | bash -s -- -b ${bin-dir} v${golangci-version}
+      - when:
+          command: "! command -v goimports"
+        command: GO111MODULE=off go get golang.org/x/tools/cmd/goimports
+      - when:
+          command: '! command -v circleci'
+        command: curl -fLSs https://circle.ci/cli | DESTDIR=${bin-dir} bash
 
   lint:
     usage: Run static analysis
@@ -76,30 +86,15 @@ tasks:
   circleci:
     usage: Run the circleci build locally
     description: |
-      Alternative to `tusk test`.
+      Alternative to `tusk test --all`.
 
-      Download the circleci agent if needed and run `circleci build`. This will
-      spin up a docker container locally and run linters and tests in an
-      environment that more closely resembles the pipeline run on CircleCI, but
-      is not easily configurable.
+      Run the local build using the CircleCI command-line tool. This will spin
+      up a docker container locally and run linters and tests in an environment
+      that more closely resembles the pipeline run on CircleCI, but is not
+      easily configurable.
 
       Requires docker to be running locally.
-    options:
-      bin-path:
-        private: true
-        default: /usr/local/bin/circleci
-      download-path:
-        private: true
-        default: https://circle-downloads.s3.amazonaws.com/releases/build_agent_wrapper/circleci
-      no-install:
-        usage: Do not install the CLI locally if not already available
-        type: bool
-    run:
-      - when:
-          - not-equal: {no-install: true}
-          - command: '! command -v circleci'
-        command: curl -o ${bin-path} ${download-path} && chmod +x ${bin-path}
-      - command: circleci build
+    run: circleci local execute --job local
 
   release:
     usage: Release the latest version with goreleaser

--- a/tusk.yml
+++ b/tusk.yml
@@ -14,7 +14,7 @@ tasks:
         default: https://install.goreleaser.com/github.com/golangci/golangci-lint.sh
       golangci-version:
         private: true
-        default: 1.15.0
+        default: 1.17.1
     run:
       - when:
           command: golangci-lint --version | grep -qv ${golangci-version}


### PR DESCRIPTION
Changes:
- Push out a new CI container with the latest versions of Go and golangci-lint
- Switch to the latest CLI recommendations for circleci
  - Simplifies the install script, which is now included in `tusk bootstrap`
  - We can now execute jobs locally which aren't named `build`, so the "local" job is now called `local`
- Bootstrapping now only installs versions if they aren't installed
- Set `GO111MODULE=off` when installing `goimports` to prevent messing with the `go.mod` and `go.sum` files
- Install golangci-lint to `/usr/local/bin` by default to match `circleci`, although it's still configurable.