### PR TITLE
Bump Go and dependency versions

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,7 +6,7 @@ branches:
 
 environment:
   GOPATH: c:\gopath
-  GO_VERSION: 1.12.6
+  GO_VERSION: 1.13
 
 install:
   # Install specific Go version

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -2,19 +2,20 @@ FROM golang:1.13
 
 WORKDIR /tusk
 
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh \
-      | bash -s -- -b $GOPATH/bin v1.18.0
-RUN go get github.com/jstemmer/go-junit-report
-RUN apt-get update && \
-      apt-get -y install rpm && \
-      curl -sL https://git.io/goreleaser > /tmp/goreleaser && \
-      chmod +x /tmp/goreleaser && \
-      mv /tmp/goreleaser /usr/local/bin
-RUN apt-get update && \
-      apt-get install -y python-pip && \
-      pip install --no-cache-dir \
-      mkdocs==1.0.4 \
-      mkdocs-rtd-dropdown==1.0.2 \
-      Pygments==2.3.0
+RUN set -e; \
+  apt-get update; \
+  apt-get install -y \
+    python-pip \
+    rpm; \
+  wget -qO- 'https://install.goreleaser.com/github.com/golangci/golangci-lint.sh' \
+    | sh -s -- -b $GOPATH/bin v1.18.0; \
+  go get github.com/jstemmer/go-junit-report; \
+  wget -qO- 'https://github.com/goreleaser/goreleaser/releases/download/v0.117.2/goreleaser_Linux_x86_64.tar.gz' \
+    | tar xvzf - -C /usr/local/bin goreleaser; \
+    chmod +x /usr/local/bin/goreleaser; \
+  pip install --no-cache-dir \
+    mkdocs==1.0.4 \
+    mkdocs-rtd-dropdown==1.0.2 \
+    Pygments==2.3.0;
 
 CMD [ "bash" ]

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.12.6
+FROM golang:1.13
 
 WORKDIR /tusk
 
 RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh \
-      | bash -s -- -b $GOPATH/bin v1.17.1
+      | bash -s -- -b $GOPATH/bin v1.18.0
 RUN go get github.com/jstemmer/go-junit-report
 RUN apt-get update && \
       apt-get -y install rpm && \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ defaults:
   job_defaults: &job_defaults
     working_directory: /tusk
     docker:
-      - image: tuskcli/ci:0.2.4
+      - image: tuskcli/ci:0.2.5
     environment: &environment_defaults
       TEST_RESULTS: /tmp/test-results
   job_dry_run: &job_dry_run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,7 @@ defaults:
   release: &release
     name: Run goreleaser
     command: |
-      # Pin goreleaser version
-      VERSION=v0.111.0 tusk --quiet release ${RELEASE_FLAGS}
+      tusk --quiet release ${RELEASE_FLAGS}
 
   publish_docs: &publish_docs
     name: Run mkdocs

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -14,6 +14,7 @@ exclude-use-default = false
 [linters]
 enable-all = true
 disable = [
+  "funlen",           # Cyclomatic complexity is more valuable than function length
   "gochecknoglobals", # There are valid use cases for globals
   "maligned",         # Readability is more important than saving bytes
   "scopelint",        # False positives in tests: https://github.com/kyoh86/scopelint/issues/4

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/rliebz/tusk
 
+go 1.13
+
 require (
 	github.com/fatih/color v1.7.0
 	github.com/google/go-cmp v0.3.1

--- a/tusk.yml
+++ b/tusk.yml
@@ -14,7 +14,7 @@ tasks:
         default: https://install.goreleaser.com/github.com/golangci/golangci-lint.sh
       golangci-version:
         private: true
-        default: 1.17.1
+        default: 1.18.0
     run:
       - when:
           command: golangci-lint --version | grep -qv ${golangci-version}


### PR DESCRIPTION
Changes:
- Bump go to version 1.13
- Bump golangci-lint to 1.18.0
  - Disable funlen (new linter as of 1.18.0)
- Bump goreleaser to 0.117.2
  - Pin goreleaser version in Dockerfile