### PR TITLE
Rework command interpreters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased 
+### Added
+- The interpreter used for running commands can now be configured using the
+  top-level `interpreter` clause in the YAML configuration.
+
+### Changed
+- The interpreter now allows for specifying an arbitrary command and series of
+  arguments, so interpreters like `node` or `ruby` that happen to use a flag
+  other than `-c` may be specified.
+- The interpreter settings now also apply to commands run as part of `when` and
+  `option` clauses.
+
+### Removed
+- **BREAKING**: To avoid inadvertantly picking up unrelated shell settings, the
+  environment variable `SHELL` is no longer considered an override for the
+  command interpreter.
 
 
 ## 0.5.2 (2020-01-26)

--- a/appcli/app.go
+++ b/appcli/app.go
@@ -113,7 +113,7 @@ func NewApp(args []string, meta *runner.Metadata) (*cli.App, error) {
 		return nil, err
 	}
 
-	cfg, err := runner.ParseComplete(meta.CfgText, taskName, argsPassed, flagsPassed)
+	cfg, err := runner.ParseComplete(meta, taskName, argsPassed, flagsPassed)
 	if err != nil {
 		return nil, err
 	}

--- a/appcli/command.go
+++ b/appcli/command.go
@@ -20,7 +20,8 @@ func createExecuteCommand(_ *cli.App, meta *runner.Metadata, t *runner.Task) (*c
 			)
 		}
 		return t.Execute(runner.Context{
-			Logger: meta.Logger,
+			Logger:      meta.Logger,
+			Interpreter: meta.Interpreter,
 		})
 	}), nil
 }

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -92,6 +92,9 @@ run:
       exec: echo "Hello!"
 ```
 
+While the interpreter cannot be set for an individual command, it is possible
+to set them globally using [the interpreter clause](#interpreter).
+
 ##### Exec
 
 The `exec` clause contains the actual shell command to be performed.
@@ -99,14 +102,13 @@ The `exec` clause contains the actual shell command to be performed.
 If any of the run commands execute with a non-zero exit code, Tusk will
 immediately exit with the same exit code without executing any other commands.
 
-Commands are executed using the `$SHELL` environment variable, defaulting to
-`sh`. Each command in a `run` clause gets its own sub-shell, so things like
-declaring functions and environment variables will not be available across
-separate run commmands, although it is possible to run the `set-environment`
-clause or use a multi-line shell command.
+Each command in a `run` clause gets its own sub-shell, so things like declaring
+functions and environment variables will not be available across separate run
+commmands, although it is possible to run the `set-environment` clause or use a
+multi-line shell command.
 
-For multi-line shell commands, to preserve the exit-on-error behavior, it is
-recommend to run `set -e` at the top of the script, much like any shell script.
+When using POSIX interpreters with multi-line scripts, it is recommend to run
+`set -e` at the top of the script, to preserve the exit-on-error behavior.
 
 ```yaml
 tasks:
@@ -617,6 +619,30 @@ run: echo "Hello, ${name}!"
 It is invalid to split the configuration; if the `include` clause is used, no
 other keys can be specified in the `tusk.yml`, and the full task must be
 defined in the included file.
+
+### Interpreter
+
+By default, any command run will default to using `sh -c` as its interpreter.
+This can optionally be configured using the `interpreter` clause.
+
+The interpreter is specified as an executable, which can either be an absolute
+path or available on the user's PATH, followed by a series of optional
+arguments:
+
+```yaml
+interpreter: node -e
+
+tasks:
+  hello:
+    run: console.log("Hello!")
+```
+
+The commands specified in individual tasks will be passed as the final
+argument. The above example is effectively equivalent to the following:
+
+```sh
+node -e 'console.log("Hello!")'
+```
 
 ### CLI Metadata
 

--- a/runner/config.go
+++ b/runner/config.go
@@ -4,6 +4,12 @@ package runner
 type Config struct {
 	Name  string `yaml:"name"`
 	Usage string `yaml:"usage"`
+	// The Interpreter field must be read before the config struct can be parsed
+	// completely from YAML. To do so, the config text parses it elsewhere in the
+	// code base independently from this struct.
+	//
+	// It is included here only so that strict unmarshaling does not fail.
+	Interpreter string `yaml:"interpreter"`
 
 	Tasks   map[string]*Task `yaml:"tasks"`
 	Options Options          `yaml:"options,omitempty"`

--- a/runner/context.go
+++ b/runner/context.go
@@ -4,7 +4,12 @@ import "github.com/rliebz/tusk/ui"
 
 // Context contains contextual information about a run.
 type Context struct {
+	// Logger is responsible for logging actions as they occur. It is required to
+	// be defined for a Context.
 	Logger *ui.Logger
+
+	// Interpreter specifies how a command is meant to be executed.
+	Interpreter []string
 
 	taskStack []*Task
 }

--- a/runner/option_test.go
+++ b/runner/option_test.go
@@ -109,7 +109,7 @@ func TestOption_Evaluate(t *testing.T) {
 	}
 
 	for _, tt := range valuetests {
-		actual, err := tt.input.Evaluate(nil)
+		actual, err := tt.input.Evaluate(Context{}, nil)
 		if err != nil {
 			t.Errorf(
 				"Option.Evaluate() for %s: unexpected err: %q",
@@ -130,7 +130,7 @@ func TestOption_Evaluate(t *testing.T) {
 func TestOption_Evaluate_required_nothing_passed(t *testing.T) {
 	option := Option{Required: true}
 
-	if _, err := option.Evaluate(nil); err == nil {
+	if _, err := option.Evaluate(Context{}, nil); err == nil {
 		t.Fatal(
 			"Option.Evaluate() for required option: expected err, actual nil",
 		)
@@ -150,7 +150,7 @@ func TestOption_Evaluate_passes_vars(t *testing.T) {
 		},
 	}
 
-	actual, err := opt.Evaluate(map[string]string{"foo": "foovalue"})
+	actual, err := opt.Evaluate(Context{}, map[string]string{"foo": "foovalue"})
 	if err != nil {
 		t.Fatalf("Option.Evaluate(): unexpected error: %s", err)
 	}
@@ -167,7 +167,7 @@ func TestOption_Evaluate_required_with_passed(t *testing.T) {
 	expected := "foo"
 	option := Option{Required: true, Passed: expected}
 
-	actual, err := option.Evaluate(nil)
+	actual, err := option.Evaluate(Context{}, nil)
 	if err != nil {
 		t.Fatalf("Option.Evaluate(): unexpected error: %s", err)
 	}
@@ -189,7 +189,7 @@ func TestOption_Evaluate_required_with_environment(t *testing.T) {
 		t.Fatalf("unexpected err setting environment variable: %s", err)
 	}
 
-	actual, err := option.Evaluate(nil)
+	actual, err := option.Evaluate(Context{}, nil)
 	if err != nil {
 		t.Fatalf("Option.Evaluate(): unexpected error: %s", err)
 	}
@@ -210,7 +210,7 @@ func TestOption_Evaluate_values_none_specified(t *testing.T) {
 		},
 	}
 
-	actual, err := option.Evaluate(nil)
+	actual, err := option.Evaluate(Context{}, nil)
 	if err != nil {
 		t.Fatalf("Option.Evaluate(): unexpected error: %s", err)
 	}
@@ -232,7 +232,7 @@ func TestOption_Evaluate_values_with_passed(t *testing.T) {
 		},
 	}
 
-	actual, err := option.Evaluate(nil)
+	actual, err := option.Evaluate(Context{}, nil)
 	if err != nil {
 		t.Fatalf("Option.Evaluate(): unexpected error: %s", err)
 	}
@@ -260,7 +260,7 @@ func TestOption_Evaluate_values_with_environment(t *testing.T) {
 		t.Fatalf("unexpected err setting environment variable: %s", err)
 	}
 
-	actual, err := option.Evaluate(nil)
+	actual, err := option.Evaluate(Context{}, nil)
 	if err != nil {
 		t.Fatalf("Option.Evaluate(): unexpected error: %s", err)
 	}
@@ -282,7 +282,7 @@ func TestOption_Evaluate_values_with_invalid_passed(t *testing.T) {
 		},
 	}
 
-	_, err := option.Evaluate(nil)
+	_, err := option.Evaluate(Context{}, nil)
 	if err == nil {
 		t.Fatalf(
 			"Option.Evaluate(): expected error for invalid passed value, got nil",
@@ -305,7 +305,7 @@ func TestOption_Evaluate_values_with_invalid_environment(t *testing.T) {
 		t.Fatalf("unexpected err setting environment variable: %s", err)
 	}
 
-	_, err := option.Evaluate(nil)
+	_, err := option.Evaluate(Context{}, nil)
 	if err == nil {
 		t.Fatalf(
 			"Option.Evaluate(): expected error for invalid environment value, got nil",
@@ -330,7 +330,7 @@ var evaluteTypeDefaultTests = []struct {
 func TestOption_Evaluate_type_defaults(t *testing.T) {
 	for _, tt := range evaluteTypeDefaultTests {
 		opt := Option{Type: tt.typeName}
-		actual, err := opt.Evaluate(nil)
+		actual, err := opt.Evaluate(Context{}, nil)
 		if err != nil {
 			t.Errorf("Option.Evaluate(): unexpected error: %s", err)
 			continue

--- a/runner/parse_test.go
+++ b/runner/parse_test.go
@@ -17,6 +17,26 @@ var interpolatetests = []struct {
 	expected RunList
 }{
 	{
+		"interpreter",
+		`
+interpreter: node
+
+tasks:
+  mytask:
+    run: console.log('Hello')
+`,
+		[]string{},
+		map[string]string{},
+		"mytask",
+		RunList{{
+			Command: CommandList{{
+				Exec:  "console.log('Hello')",
+				Print: "console.log('Hello')",
+			}},
+		}},
+	},
+
+	{
 		"argument interpolation",
 		`
 tasks:
@@ -801,7 +821,11 @@ given input:
 			tt.testCase, tt.taskName, tt.flags, tt.input,
 		)
 
-		cfg, err := ParseComplete([]byte(tt.input), tt.taskName, tt.args, tt.flags)
+		meta := &Metadata{
+			CfgText: []byte(tt.input),
+		}
+
+		cfg, err := ParseComplete(meta, tt.taskName, tt.args, tt.flags)
 		if err != nil {
 			t.Errorf(context+"unexpected error parsing text: %s", err)
 			continue
@@ -997,7 +1021,11 @@ given input:
 			tt.testCase, tt.taskName, tt.flags, tt.input,
 		)
 
-		_, err := ParseComplete([]byte(tt.input), tt.taskName, tt.args, tt.flags)
+		meta := &Metadata{
+			CfgText: []byte(tt.input),
+		}
+
+		_, err := ParseComplete(meta, tt.taskName, tt.args, tt.flags)
 		if err == nil {
 			t.Errorf(context+"expected error for test case: %s", tt.testCase)
 			continue
@@ -1017,7 +1045,11 @@ tasks:
     run: echo ${bar}
 `)
 
-	cfg, err := ParseComplete(cfgText, "", []string{}, map[string]string{})
+	meta := &Metadata{
+		CfgText: cfgText,
+	}
+
+	cfg, err := ParseComplete(meta, "", []string{}, map[string]string{})
 	if err != nil {
 		t.Fatalf("unexpected error parsing text: %s", err)
 	}

--- a/runner/run.go
+++ b/runner/run.go
@@ -56,7 +56,7 @@ func (r *Run) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 func (r *Run) shouldRun(ctx Context, vars map[string]string) (bool, error) {
-	if err := r.When.Validate(vars); err != nil {
+	if err := r.When.Validate(ctx, vars); err != nil {
 		if !IsFailedCondition(err) {
 			return false, err
 		}

--- a/runner/value.go
+++ b/runner/value.go
@@ -2,7 +2,6 @@ package runner
 
 import (
 	"fmt"
-	"os/exec"
 	"strings"
 
 	"github.com/rliebz/tusk/marshal"
@@ -17,9 +16,11 @@ type Value struct {
 }
 
 // commandValueOrDefault validates a content definition, then gets the value.
-func (v *Value) commandValueOrDefault() (string, error) {
+func (v *Value) commandValueOrDefault(ctx Context) (string, error) {
 	if v.Command != "" {
-		out, err := exec.Command("sh", "-c", v.Command).Output() // nolint: gosec
+		cmd := newCmd(ctx, v.Command)
+
+		out, err := cmd.Output()
 		if err != nil {
 			return "", err
 		}

--- a/runner/when_test.go
+++ b/runner/when_test.go
@@ -354,7 +354,7 @@ var whenValidateTests = []struct {
 
 func TestWhen_Validate(t *testing.T) {
 	for _, tt := range whenValidateTests {
-		err := tt.when.Validate(tt.options)
+		err := tt.when.Validate(Context{}, tt.options)
 		didErr := err != nil
 		if tt.shouldErr != didErr {
 			t.Errorf(
@@ -534,7 +534,7 @@ var listValidateTests = []struct {
 
 func TestList_Validate(t *testing.T) {
 	for _, tt := range listValidateTests {
-		err := tt.list.Validate(tt.options)
+		err := tt.list.Validate(Context{}, tt.options)
 		didErr := err != nil
 		if tt.shouldErr != didErr {
 			t.Errorf(
@@ -547,7 +547,7 @@ func TestList_Validate(t *testing.T) {
 
 func TestList_Validate_nil(t *testing.T) {
 	var l *WhenList
-	if err := l.Validate(map[string]string{}); err != nil {
+	if err := l.Validate(Context{}, map[string]string{}); err != nil {
 		t.Errorf("unexpected error: %s", err)
 	}
 }


### PR DESCRIPTION
Rework command interpreters

Using the `SHELL` environment variable to determine the command
interpreter was problematic because the variable signals the shell that
is being used, not the shell that is intended to run scripts in a
project. That said, for systems that do not have have an executable on
their path named `sh`, or if `sh` is less desirable, there needs to be a
way to specify what should be used instead.

The solution here is to allow users to specify their own interpreter and
the flags needed to invoke it. This effectively removes the requirement
for an interpreter to match the following pattern:

    ${SHELL} -c "..."

The range of supported interpreters is therefore expanded to include
anything that can run an arbitrary script passed as a string, such as
node or ruby, whether or not they happen to have a `-c` flag.

This setting may only be specified at the file level rather than the
task level. While there may be semantics that make sense to allow for
more granular specification of the interpreter, those are not currently
clear to me, and I don't necessarily know that they are worth
supporting.

This change also unifies commands run during `when` or `option` clauses
so that they respect the interpreter setting the same way that a `command`
does.

Resolves: #72
