### PR TITLE
Bump go/golangci-lint versions

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14
+FROM golang:1.15
 
 WORKDIR /tusk
 
@@ -8,7 +8,7 @@ RUN set -e; \
     python3-pip \
     rpm; \
   wget -qO- 'https://install.goreleaser.com/github.com/golangci/golangci-lint.sh' \
-    | sh -s -- -b $GOPATH/bin v1.23.7; \
+    | sh -s -- -b $GOPATH/bin v1.30.0; \
   go get github.com/jstemmer/go-junit-report; \
   wget -qO- 'https://github.com/goreleaser/goreleaser/releases/download/v0.117.2/goreleaser_Linux_x86_64.tar.gz' \
     | tar xvzf - -C /usr/local/bin goreleaser; \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ defaults:
   job_defaults: &job_defaults
     working_directory: /tusk
     docker:
-      - image: tuskcli/ci:0.2.7
+      - image: tuskcli/ci:0.2.8
     environment: &environment_defaults
       TEST_RESULTS: /tmp/test-results
   job_dry_run: &job_dry_run

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -8,6 +8,8 @@ exclude = [
   'G104: Errors unhandled',
   # gosec: Allow file inclusions
   'G304: Potential file inclusion via variable',
+  # gosec: Duplicate of errcheck
+  'G307: Deferring unsafe method',
 ]
 exclude-use-default = false
 
@@ -22,9 +24,7 @@ exclude-use-default = false
 
 [linters]
 enable = [
-  "bodyclose",
   "golint",
-  "stylecheck",
   "gosec",
   "interfacer",
   "unconvert",
@@ -32,16 +32,20 @@ enable = [
   "goconst",
   "gocyclo",
   "gocognit",
+  "asciicheck",
   "gofmt",
   "goimports",
-  "lll",
   "misspell",
+  "lll",
   "unparam",
   "nakedret",
   "prealloc",
   "gocritic",
   "gochecknoinits",
   "whitespace",
+  "nestif",
+  "exportloopref",
+  "nolintlint",
 ]
 
 [linters-settings]

--- a/appcli/app_test.go
+++ b/appcli/app_test.go
@@ -1,6 +1,7 @@
 package appcli
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -358,7 +359,7 @@ func TestGetConfigMetadata_fileNoExist(t *testing.T) {
 	args := []string{"tusk", "--file", "fakefile.yml"}
 
 	_, err := GetConfigMetadata(args)
-	if !os.IsNotExist(err) {
+	if !errors.Is(err, os.ErrNotExist) {
 		t.Errorf(
 			"GetConfigMetadata(%s): unexpected err: os.IsNotExist, actual: %s",
 			args, err,

--- a/appcli/install_completion.go
+++ b/appcli/install_completion.go
@@ -195,6 +195,8 @@ func installFileInDir(logger *ui.Logger, dir, file string, content []byte) error
 	}
 
 	target := filepath.Join(dir, file)
+
+	// nolint: gosec
 	if err := ioutil.WriteFile(target, content, 0644); err != nil {
 		return err
 	}

--- a/runner/arg_test.go
+++ b/runner/arg_test.go
@@ -61,7 +61,6 @@ func TestEvaluate_nil(t *testing.T) {
 	}
 }
 
-// nolint: dupl
 func TestGetArgsWithOrder(t *testing.T) {
 	name := "foo"
 	usage := "use me"

--- a/runner/command_test.go
+++ b/runner/command_test.go
@@ -106,7 +106,7 @@ func TestCommand_exec(t *testing.T) {
 			execCommand = func(name string, arg ...string) *exec.Cmd {
 				cs := []string{"-test.run=TestCommand_exec_helper", "--", name}
 				cs = append(cs, arg...)
-				cmd := exec.Command(os.Args[0], cs...) // nolint: gosec
+				cmd := exec.Command(os.Args[0], cs...)
 				cmd.Env = []string{
 					"TUSK_TEST_EXEC_COMMAND=1",
 					"TUSK_TEST_COMMAND_ARGS=" + strings.Join(tt.want, ","),

--- a/runner/dependencies.go
+++ b/runner/dependencies.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rliebz/tusk/marshal"
 )
 
-// FindAllOptions returns a list of options relevant for a given
+// FindAllOptions returns a list of options relevant for a given config.
 func FindAllOptions(t *Task, cfg *Config) ([]*Option, error) {
 	names, err := getDependencies(t)
 	if err != nil {

--- a/runner/file.go
+++ b/runner/file.go
@@ -27,22 +27,22 @@ var defaultFiles = []string{"tusk.yml", "tusk.yaml"}
 // find a configuration file with the default name.
 // This should be called when an explicit file is not passed in to determine
 // the full path to the relevant config file.
-func searchForFile() (fullPath string, found bool, err error) {
+func searchForFile() (string, error) {
 	prevPath := ""
 	dirPath, err := os.Getwd()
 	if err != nil {
-		return "", false, err
+		return "", err
 	}
 
 	for dirPath != prevPath {
-		fullPath, found, err = findFileInDir(dirPath)
+		fullPath, found, err := findFileInDir(dirPath)
 		if err != nil || found {
-			return fullPath, found, err
+			return fullPath, err
 		}
 		prevPath, dirPath = dirPath, filepath.Dir(dirPath)
 	}
 
-	return "", false, nil
+	return "", nil
 }
 
 func findFileInDir(dirPath string) (fullPath string, found bool, err error) {

--- a/runner/file_test.go
+++ b/runner/file_test.go
@@ -50,34 +50,28 @@ func TestSearchForFile(t *testing.T) {
 	inheritedDir := mkDir(t, topDir, "baz", "empty")
 
 	testcases := []struct {
-		wd    string
-		path  string
-		found bool
+		wd   string
+		path string
 	}{
 		{
-			wd:    emptyDir,
-			path:  "",
-			found: false,
+			wd:   emptyDir,
+			path: "",
 		},
 		{
-			wd:    topDir,
-			path:  topConfig,
-			found: true,
+			wd:   topDir,
+			path: topConfig,
 		},
 		{
-			wd:    yamlDir,
-			path:  yamlConfig,
-			found: true,
+			wd:   yamlDir,
+			path: yamlConfig,
 		},
 		{
-			wd:    nestedDir,
-			path:  nestedConfig,
-			found: true,
+			wd:   nestedDir,
+			path: nestedConfig,
 		},
 		{
-			wd:    inheritedDir,
-			path:  topConfig,
-			found: true,
+			wd:   inheritedDir,
+			path: topConfig,
 		},
 	}
 
@@ -86,7 +80,7 @@ func TestSearchForFile(t *testing.T) {
 			t.Fatalf("failed to change directory: %v", err)
 		}
 
-		fullPath, found, err := searchForFile()
+		fullPath, err := searchForFile()
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 			continue
@@ -96,13 +90,6 @@ func TestSearchForFile(t *testing.T) {
 			t.Errorf(
 				"SearchForFile(): expected path: %s, actual: %s",
 				tt.path, fullPath,
-			)
-		}
-
-		if tt.found != found {
-			t.Errorf(
-				"SearchForFile(): expected found: %v, actual: %v",
-				tt.found, found,
 			)
 		}
 	}

--- a/runner/metadata.go
+++ b/runner/metadata.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"strings"
@@ -32,24 +33,21 @@ type Metadata struct {
 
 // Set sets the metadata based on options.
 func (m *Metadata) Set(o OptGetter) error {
-	var err error
-
 	fullPath := o.String("file")
-	if fullPath != "" {
-		if m.CfgText, err = ioutil.ReadFile(fullPath); err != nil {
-			return err
-		}
-	} else {
-		var found bool
-		fullPath, found, err = searchForFile()
+
+	if fullPath == "" {
+		var err error
+		fullPath, err = searchForFile()
 		if err != nil {
 			return err
 		}
+	}
 
-		if found {
-			if m.CfgText, err = ioutil.ReadFile(fullPath); err != nil {
-				return err
-			}
+	if fullPath != "" {
+		var err error
+		m.CfgText, err = ioutil.ReadFile(fullPath)
+		if err != nil {
+			return fmt.Errorf("reading config file %q: %w", fullPath, err)
 		}
 	}
 

--- a/runner/option_test.go
+++ b/runner/option_test.go
@@ -410,7 +410,6 @@ func TestOption_UnmarshalYAML_invalid_definitions(t *testing.T) {
 	}
 }
 
-// nolint: dupl
 func TestGetOptionsWithOrder(t *testing.T) {
 	name := "foo"
 	env := "fooenv"

--- a/tusk.yml
+++ b/tusk.yml
@@ -14,7 +14,7 @@ tasks:
         default: https://install.goreleaser.com/github.com/golangci/golangci-lint.sh
       golangci-version:
         private: true
-        default: 1.23.7
+        default: 1.30.0
     run:
       - when:
           command: golangci-lint --version | grep -qv ${golangci-version}


### PR DESCRIPTION
Add in some new linters, remove some irrelevant ones, and fix minor
issues flagged by golangci-lint.